### PR TITLE
modify:Claude Actionsの設定変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,16 +37,16 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            このプルリクエストを日本語でレビューし、以下の点についてフィードバックを提供してください:
+            - コード品質とベストプラクティス
+            - 潜在的なバグや問題
+            - パフォーマンスに関する考慮事項
+            - セキュリティ上の懸念
+            - テストカバレッジ
             
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            リポジトリのCLAUDE.mdファイルがあれば、スタイルと規約のガイダンスとして使用してください。建設的で役立つフィードバックを心がけてください。
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Bashツールで`gh pr comment`を使用して、PRにレビューをコメントとして残してください。
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request_review_comment:
+    types: [created]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
### 📋 PR概要: Claude Actionsの日本語対応設定

このPRでは、Claude Code ReviewワークフローをトリガーとプロンプトのJapanese対応に設定変更しています。

#### 🔄 主な変更点

**1. トリガーの変更**
```yaml
# 変更前
on:
  pull_request:
    types: [opened, synchronize]

# 変更後  
on:
  pull_request_review_comment:
    types: [created]
```
- PRが作成・更新時の自動実行から、PRコメント作成時の実行に変更

**2. プロンプトの日本語化**
- 英語のレビュープロンプトを完全に日本語に翻訳
- レビュー観点も日本語で明記:
  - コード品質とベストプラクティス
  - 潜在的なバグや問題
  - パフォーマンスに関する考慮事項
  - セキュリティ上の懸念
  - テストカバレッジ

#### ✅ 実装結果

この変更により、Claude Actionsは以下のように動作します:

1. **トリガー**: PRレビューコメントが作成された時に実行
2. **レビュー言語**: 日本語でコードレビューを実施
3. **フィードバック**: 建設的で役立つ日本語フィードバックを提供
4. **出力**: `gh pr comment`を使用してPRにコメントとして投稿

#### 📝 注意事項

前回のClaudeコメントで言及されているように、GitHub Appの制限により`.github/workflows/`ディレクトリへの直接プッシュには制限がありますが、このPRでは変更が正常に反映されています。

---

**Branch**: [modify-claude-actions](https://github.com/Takao-Yamasaki/react-basis/tree/modify-claude-actions) | **Job**: [View details](https://github.com/Takao-Yamasaki/react-basis/actions/runs/10731442536)